### PR TITLE
Add user INSERT and existance check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "command_attr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,6 +169,7 @@ dependencies = [
  "byteorder",
  "diesel_derives",
  "pq-sys",
+ "r2d2",
 ]
 
 [[package]]
@@ -478,6 +488,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b141fdc7836c525d4d594027d318c84161ca17aaf8113ab1f81ab93ae897485"
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,6 +544,15 @@ name = "lock_api"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28247cc5a5be2f05fbcd76dd0cf2c7d3b5400cb978a28042abcd4fa0b3f8261c"
 dependencies = [
  "scopeguard",
 ]
@@ -684,9 +709,20 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 dependencies = [
- "lock_api",
- "parking_lot_core",
+ "lock_api 0.3.4",
+ "parking_lot_core 0.6.2",
  "rustc_version",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
+dependencies = [
+ "instant",
+ "lock_api 0.4.1",
+ "parking_lot_core 0.8.0",
 ]
 
 [[package]]
@@ -696,11 +732,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 dependencies = [
  "cfg-if",
- "cloudabi",
+ "cloudabi 0.0.3",
  "libc",
  "redox_syscall",
  "rustc_version",
- "smallvec",
+ "smallvec 0.6.13",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
+dependencies = [
+ "cfg-if",
+ "cloudabi 0.1.0",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec 1.4.1",
  "winapi 0.3.9",
 ]
 
@@ -785,6 +836,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r2d2"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "545c5bc2b880973c9c10e4067418407a0ccaa3091781d1671d46eb35107cb26f"
+dependencies = [
+ "log",
+ "parking_lot 0.11.0",
+ "scheduled-thread-pool",
 ]
 
 [[package]]
@@ -927,6 +989,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
+name = "scheduled-thread-pool"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6f74fd1204073fa02d5d5d68bec8021be4c38690b61264b2fdb48083d0e7d7"
+dependencies = [
+ "parking_lot 0.11.0",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1018,7 +1089,7 @@ dependencies = [
  "command_attr",
  "flate2",
  "log",
- "parking_lot",
+ "parking_lot 0.9.0",
  "reqwest",
  "rustls 0.16.0",
  "serde",
@@ -1059,6 +1130,12 @@ checksum = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
 dependencies = [
  "maybe-uninit",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3757cb9d89161a2f24e1cf78efa0c1fcff485d18e3f55e0aa3480824ddaa0f3f"
 
 [[package]]
 name = "socket2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ version = "0.1.0"
 
 [dependencies]
 serenity = "0.8.6"
-diesel={version="1", features=["postgres"]}
+diesel={version="1", features=["postgres", "r2d2"]}
 dotenv = "0.15.0"

--- a/sample.env
+++ b/sample.env
@@ -1,1 +1,0 @@
-DATABASE_URL=postgres://postgres:password@localhost/utilbot

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,69 +1,120 @@
 #[macro_use]
 extern crate diesel;
 extern crate dotenv;
+extern crate serenity;
 
 use diesel::prelude::*;
-use diesel::pg::PgConnection;
 use dotenv::dotenv;
 
 use std::env;
-// use std::collections::HashSet;
-use std::fs::File;
-use std::io::prelude::*;
 
-use serenity::prelude::*;
-use serenity::model::gateway::Ready;
 use serenity::model::channel::{Message, Reaction};
+use serenity::model::gateway::Ready;
+use serenity::prelude::*;
 
 mod schema;
+use schema::user;
 
 struct Handler;
 
-// struct User {
-//     id: serenity::model::id::UserId,
-//     languages: HashSet<String>,
-// }
+type Pool = diesel::r2d2::Pool<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
-pub fn establish_connection() -> PgConnection {
-    dotenv().ok();
+#[derive(Insertable)]
+#[table_name = "user"]
+struct NewUser<'a> {
+    discord_id: i32,
+    languages: &'a str,
+}
 
-    let database_url = env::var("DATABASE_URL")
-        .expect("DATABASE_URL must be set");
-    PgConnection::establish(&database_url)
-        .expect(&format!("Error connecting to {}", database_url))
+#[derive(Queryable)]
+struct User {
+    id: i32,
+    discord_id: i32,
+    languages: String,
+}
+
+struct PooledConnection(Pool);
+
+impl TypeMapKey for PooledConnection {
+    type Value = Pool;
+}
+
+fn is_user_exist (id: &u64, connection_pool: &Pool) -> bool {
+    use diesel::expression::exists;
+    use schema::user::dsl as user_dsl;
+
+    diesel::select(exists::exists(
+        schema::user::dsl::user.filter(user_dsl::discord_id.eq(*id as i32)),
+    )).get_result::<bool>(&connection_pool.get().unwrap())
+    .unwrap()
+}
+
+fn insert_user(id: &u64, languages: &String, connection_pool: &Pool) {
+    // NewUser is the struct used for inserting into the database
+    diesel::insert_into(schema::user::dsl::user).values(NewUser {
+        discord_id: *id as i32,
+        languages: languages,
+    })
+    .execute(&connection_pool.get().unwrap())
+    .unwrap();
 }
 
 impl EventHandler for Handler {
-    fn reaction_add(&self, _ctx: Context, _add_reaction: Reaction) {
+    fn reaction_add(&self, context: Context, add_reaction: Reaction) {
 
     }
 
-    fn message(&self, _ctx: Context, _message: Message) {
+    fn message(&self, context: Context, message: Message) {
+        let mut data = context.data.write();
+        let connection_pool = data.get_mut::<PooledConnection>().unwrap();
 
+        // Sample parsing of message 
+        let message_tokens:Vec<&str> = message.content.split(" ").collect();
+        let message_author_id = message.author.id.0;
+
+        if message_tokens[0] == "!utilbot" {
+
+            // Test existance of message sender
+            if is_user_exist(&message_author_id, connection_pool) {
+                println!("You're already in the database and your ID is {}", message_author_id);
+                // TODO: Add query here to verify that user has been added
+            
+            // Insert new user that sent the message
+            } else {
+                insert_user(&message.author.id.0, &message.content, connection_pool);
+                println!("You've been added to the database. Your ID is {}", message_author_id)
+            }
+        }
+                
+        // Test existance of random user_id and print result
+        let test2: bool = is_user_exist(&032458097234, connection_pool);
+        // Print results
+        println!("UserID: {} Exists: {}", 1203948799, test2);
     }
 
-    fn ready(&self, _ctx: Context, bot_status: Ready) {
+    fn ready(&self, context: Context, bot_status: Ready) {
         println!("{} is ready", bot_status.user.name);
     }
 }
 
-
 fn main() {
-    // let connection = establish_connection();
-
-    // let connection = establish_connection();
-
-    let mut file = File::open(".token").unwrap();
-    let mut token = String::new();
-
-    file.read_to_string(&mut token)
-        .expect("Token File not found");
-
-    let mut client = Client::new(&token, Handler).expect("Error creating client");
-
-    // Logs to console if there is an error running the bot
-    if let Err(message) = client.start() {
-        println!("Error: {:?}", message);
+    dotenv().ok();
+    let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set in .env file");
+    let pool: Pool = diesel::r2d2::Pool::new(diesel::r2d2::ConnectionManager::new(database_url)).expect("Failed to build pool.");
+    let mut client = Client::new(
+        env::var("DISCORD_TOKEN").expect("Missing token"),
+        Handler,
+    )
+    .expect("Error creating client");
+    client.with_framework(
+        serenity::framework::standard::StandardFramework::new()
+            .configure(|c| c.prefix("~").allow_dm(true)),
+    );
+    {
+        let mut data = client.data.write();
+        data.insert::<PooledConnection>(pool);
     }
-    println!("Hello, world!");
+    if let Err(why) = client.start() {
+        println!("Error starting the Discord client: {:?}", why);
+    }
 }


### PR DESCRIPTION
This PR introduces PostgreSQL INSERT functions

Make a `.env` file in the root dir and add the following tokens
```
DATABASE_URL=...
DISCORD_TOKEN=...
```
The `var`s will look something like:
 - `DATABASE_URL` : `postgres://postgres:password@localhost/utilbot` 
 - `DISCORD_TOKEN` : `NzMyMzA4NjYwMTIzMDkwOTU5.Xw45ag.h-oSnTeJAXjJtfhv86Xim2ohw_g`

Run `diesel setup` to setup the DB if it didn't exist before. Note: This might add another migrations folder, haven't tested that

Run `diesel migration redo` to reset the tables. This essentially runs what is in `migrations\2020-07-14-201754_model\down.sql` and then `migrations\2020-07-14-201754_model\up.sql`

**PS**: A querying function has yet to be added, gonna work on that after this PR

